### PR TITLE
修复：代码中配置展示的行数不生效的问题

### DIFF
--- a/transformerslayout/src/main/java/com/zaaach/transformerslayout/TransformersLayout.java
+++ b/transformerslayout/src/main/java/com/zaaach/transformerslayout/TransformersLayout.java
@@ -185,7 +185,7 @@ public class TransformersLayout<T> extends LinearLayout {
             scrollBarThumbColor = options.scrollBarThumbColor == 0 ? DEFAULT_THUMB_COLOR : options.scrollBarThumbColor;
 
             if (newLines != lines){
-                recyclerView.setLayoutManager(new GridLayoutManager(getContext(), lines, GridLayoutManager.HORIZONTAL, false));
+                recyclerView.setLayoutManager(new GridLayoutManager(getContext(), newLines, GridLayoutManager.HORIZONTAL, false));
             }
             setupScrollBar();
         }


### PR DESCRIPTION
TransformersOptions options = new TransformersOptions.Builder()
                .lines(1)
配置完,结果还是展示默认的2行,进行了简单修复~